### PR TITLE
Updated to work with current webpack (4.x) and UglifyJS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,12 +1,15 @@
 var path = require("path");
 var webpack = require("webpack");
 
+const UglifyJsPlugin = require("uglifyjs-webpack-plugin");
+
 var PATHS = {
   entryPoint: path.resolve(__dirname, 'src/index.ts'),
   bundles: path.resolve(__dirname, '_bundles'),
 }
 
 var config = {
+  mode: 'production', // suppress warning
   // These are the entry point of our library. We tell webpack to use
   // the name we assign later, when creating the bundle. We also use
   // the name to filter the second entry point for applying code
@@ -31,36 +34,40 @@ var config = {
   resolve: {
     extensions: ['.ts', '.tsx', '.js']
   },
-  // Activate source maps for the bundles in order to preserve the original
-  // source when the user debugs the application
   devtool: 'source-map',
-  plugins: [
-    // Apply minification only on the second bundle by
-    // using a RegEx on the name, which must end with `.min.js`
-    // NB: Remember to activate sourceMaps in UglifyJsPlugin
-    // since they are disabled by default!
-    new webpack.optimize.UglifyJsPlugin({
-      minimize: true,
-      sourceMap: true,
-      include: /\.min\.js$/,
-    })
-  ],
   module: {
     // Webpack doesn't understand TypeScript files and a loader is needed.
     // `node_modules` folder is excluded in order to prevent problems with
     // the library dependencies, as well as `__tests__` folders that
     // contain the tests for the library
-    loaders: [{
+    rules: [{
       test: /\.tsx?$/,
       loader: 'awesome-typescript-loader',
       exclude: /node_modules/,
       query: {
         // we don't want any declaration file in the bundles
-        // folder since it wouldn't be of any use ans the source
+        // folder since it wouldn't be of any use and the source
         // map already include everything for debugging
         declaration: false,
       }
     }]
+  },
+  optimization: {
+    minimizer: [
+        // Apply minification only on the second bundle by
+        // using a RegEx on the name, which must end with `.min.js`
+        // NB: Remember to activate sourceMaps in UglifyJsPlugin
+        // since they are disabled by default!
+        new UglifyJsPlugin({
+            include: /\.min\.js$/,
+            cache: true,
+            parallel: true,
+            uglifyOptions: {
+                minimize: true
+            },
+            sourceMap: true
+        })
+      ]
   }
 }
 


### PR DESCRIPTION
Your example was really helpful as I worked through packaging a typescript component (thanks!), but I found a handful of details that no longer worked as illustrated in the example. I can't say with confidence that the attached is optimal, but it seems to produce the desired result, and I think is functionally equivalent to the original (but in a way that works with current versions of things).